### PR TITLE
feat: 내부 캘린더 기능 구현 및 전체 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,13 +43,13 @@ android {
              * ======================================== */
 
             // 기본 설정: 에뮬레이터용
-//            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000\"")
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000\"")
 
             // 실제 디바이스 USB 연결 시 아래 주석 해제하고 위 줄 주석 처리
-             buildConfigField("String", "BASE_URL", "\"http://localhost:8000\"")
+             //buildConfigField("String", "BASE_URL", "\"http://192.168.0.105:8000\"")
 
             // Wi-Fi 연결 시 PC IP로 변경
-            // buildConfigField("String", "BASE_URL", "\"http://192.168.0.10:8000\"")
+             //buildConfigField("String", "BASE_URL", "\"http://192.168.0.105:8000\"")
 
             isDebuggable = true
         }

--- a/app/src/main/java/com/example/mobile_android/data/local/AppDatabase.java
+++ b/app/src/main/java/com/example/mobile_android/data/local/AppDatabase.java
@@ -6,14 +6,17 @@ import androidx.room.Database;
 import androidx.room.Room;
 import androidx.room.RoomDatabase;
 
+import com.example.mobile_android.model.Post;
+
 /**
- * Room database entry point. Keeps notification history on-device so it survives process death.
+ * Room database entry point.
  */
 @Database(
         entities = {
-                NotificationEntity.class
+                NotificationEntity.class,
+                Post.class // Post 저장을 위해 추가
         },
-        version = 1,
+        version = 2, // 데이터베이스 스키마 변경으로 버전 업데이트
         exportSchema = false
 )
 public abstract class AppDatabase extends RoomDatabase {
@@ -23,6 +26,8 @@ public abstract class AppDatabase extends RoomDatabase {
 
     public abstract NotificationDao notificationDao();
 
+    public abstract PostDao postDao(); // Post 데이터 관리를 위한 DAO 추가
+
     public static AppDatabase getInstance(Context context) {
         if (INSTANCE == null) {
             synchronized (AppDatabase.class) {
@@ -31,7 +36,10 @@ public abstract class AppDatabase extends RoomDatabase {
                             context.getApplicationContext(),
                             AppDatabase.class,
                             DB_NAME
-                    ).build();
+                    )
+                    // 개발 중 스키마 변경 시, 기존 데이터를 삭제하고 새로 시작 (마이그레이션 불필요)
+                    .fallbackToDestructiveMigration()
+                    .build();
                 }
             }
         }

--- a/app/src/main/java/com/example/mobile_android/data/local/PostDao.java
+++ b/app/src/main/java/com/example/mobile_android/data/local/PostDao.java
@@ -52,18 +52,27 @@ public abstract class PostDao {
 
     /**
      * 특정 Post가 저장되어 있는지 확인합니다.
+     * @return 저장되어 있다면 true, 아니거나 없으면 false 또는 null
      */
-    @Query("SELECT isSaved FROM post WHERE id = :postId")
-    public abstract boolean isPostSaved(String postId);
+    @Query("SELECT isSaved FROM post WHERE id = :postId LIMIT 1")
+    public abstract Boolean isPostSaved(String postId);
 
     /**
      * 네트워크에서 가져온 Post 목록을 데이터베이스에 삽입/업데이트(upsert)합니다.
+     * 만약 Post가 이미 존재하면, 기존의 isSaved 상태를 유지한 채 나머지 정보만 업데이트합니다.
      */
     @Transaction
     public void upsert(List<Post> posts) {
+        // posts 리스트가 null이거나 비어있으면 아무것도 하지 않음 (NPE 방지)
+        if (posts == null || posts.isEmpty()) {
+            return;
+        }
+
         for (Post post : posts) {
-            boolean isSaved = isPostSaved(post.getId());
-            post.setSaved(isSaved);
+            // 기존 저장 상태를 확인 (결과가 없으면 null)
+            Boolean isSaved = isPostSaved(post.getId());
+            // isSaved가 null이면 false로 처리하여 안전하게 set
+            post.setSaved(Boolean.TRUE.equals(isSaved));
             insert(post);
         }
     }

--- a/app/src/main/java/com/example/mobile_android/data/local/PostDao.java
+++ b/app/src/main/java/com/example/mobile_android/data/local/PostDao.java
@@ -1,0 +1,70 @@
+package com.example.mobile_android.data.local;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Transaction;
+
+import com.example.mobile_android.model.Post;
+
+import java.util.List;
+
+@Dao
+public abstract class PostDao {
+
+    /**
+     * 특정 ID의 Post를 조회합니다.
+     */
+    @Query("SELECT * FROM post WHERE id = :postId")
+    public abstract LiveData<Post> getPostById(String postId);
+
+    /**
+     * 특정 사이트의 모든 Post를 최신순으로 조회합니다.
+     */
+    @Query("SELECT * FROM post WHERE siteId = :siteId ORDER BY createdAt DESC")
+    public abstract LiveData<List<Post>> getPostsBySite(String siteId);
+
+    /**
+     * 데이터베이스의 모든 Post를 최신순으로 조회합니다.
+     */
+    @Query("SELECT * FROM post ORDER BY createdAt DESC")
+    public abstract LiveData<List<Post>> getAllPosts();
+
+    /**
+     * 캘린더에 저장된 모든 Post를 조회합니다.
+     */
+    @Query("SELECT * FROM post WHERE isSaved = 1 ORDER BY eventStartDate DESC")
+    public abstract LiveData<List<Post>> getSavedPosts();
+
+    /**
+     * 특정 Post의 캘린더 저장 상태를 업데이트합니다.
+     */
+    @Query("UPDATE post SET isSaved = :isSaved WHERE id = :postId")
+    public abstract void updateSaveState(String postId, boolean isSaved);
+
+    /**
+     * 단일 Post를 데이터베이스에 삽입 또는 교체합니다.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    public abstract void insert(Post post);
+
+    /**
+     * 특정 Post가 저장되어 있는지 확인합니다.
+     */
+    @Query("SELECT isSaved FROM post WHERE id = :postId")
+    public abstract boolean isPostSaved(String postId);
+
+    /**
+     * 네트워크에서 가져온 Post 목록을 데이터베이스에 삽입/업데이트(upsert)합니다.
+     */
+    @Transaction
+    public void upsert(List<Post> posts) {
+        for (Post post : posts) {
+            boolean isSaved = isPostSaved(post.getId());
+            post.setSaved(isSaved);
+            insert(post);
+        }
+    }
+}

--- a/app/src/main/java/com/example/mobile_android/model/Post.java
+++ b/app/src/main/java/com/example/mobile_android/model/Post.java
@@ -2,44 +2,73 @@ package com.example.mobile_android.model;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.Ignore;
+import androidx.room.PrimaryKey;
 import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
+@Entity(tableName = "post")
 public class Post implements Serializable, Parcelable {
+
+    @PrimaryKey
+    @NonNull
     @SerializedName("id")
     private String id;
+
     @SerializedName("site_id")
     private String siteId;
+
     @SerializedName("title")
     private String title;
+
     @SerializedName("content")
     private String content;
+
     @SerializedName("source_url")
     private String sourceUrl;
+
     @SerializedName("event_date")
     private String eventDate;
+
     @SerializedName("event_start_date")
     private String eventStartDate;
+
     @SerializedName("event_end_date")
     private String eventEndDate;
+
     @SerializedName("location")
     private String location;
+
     @SerializedName("category")
     private String category;
+
     @SerializedName("created_at")
     private String createdAt;
+
     @SerializedName("updated_at")
     private String updatedAt;
+
     @SerializedName("category_name")
     private String categoryName;
+
     @SerializedName("site_name")
     private String siteName;
+
     @SerializedName("is_new")
     private Boolean isNew;
 
-    // Constructors
-    public Post(String id, String siteId, String title, String content, String sourceUrl,
+    @ColumnInfo(defaultValue = "0")
+    public boolean isSaved = false;
+
+    public Post() {}
+
+    @Ignore // Room will ignore this constructor
+    public Post(@NonNull String id, String siteId, String title, String content, String sourceUrl,
                 String eventDate, String eventStartDate, String eventEndDate,
                 String location, String category, String createdAt, String updatedAt,
                 String categoryName, String siteName, Boolean isNew) {
@@ -77,9 +106,11 @@ public class Post implements Serializable, Parcelable {
         siteName = in.readString();
         byte tmpIsNew = in.readByte();
         isNew = tmpIsNew == 0 ? null : tmpIsNew == 1;
+        isSaved = in.readByte() != 0;
     }
 
-    // Getters
+    // ... Getters and Setters ...
+    @NonNull
     public String getId() { return id; }
     public String getSiteId() { return siteId; }
     public String getTitle() { return title; }
@@ -95,7 +126,41 @@ public class Post implements Serializable, Parcelable {
     public String getCategoryName() { return categoryName; }
     public String getSiteName() { return siteName; }
     public Boolean getIsNew() { return isNew; }
+    public boolean isSaved() { return isSaved; }
 
+    public void setId(@NonNull String id) { this.id = id;}
+    public void setSiteId(String siteId) { this.siteId = siteId; }
+    public void setTitle(String title) { this.title = title; }
+    public void setContent(String content) { this.content = content; }
+    public void setSourceUrl(String sourceUrl) { this.sourceUrl = sourceUrl; }
+    public void setEventDate(String eventDate) { this.eventDate = eventDate; }
+    public void setEventStartDate(String eventStartDate) { this.eventStartDate = eventStartDate; }
+    public void setEventEndDate(String eventEndDate) { this.eventEndDate = eventEndDate; }
+    public void setLocation(String location) { this.location = location; }
+    public void setCategory(String category) { this.category = category; }
+    public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
+    public void setUpdatedAt(String updatedAt) { this.updatedAt = updatedAt; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public void setSiteName(String siteName) { this.siteName = siteName; }
+    public void setIsNew(Boolean isNew) { this.isNew = isNew; }
+    public void setSaved(boolean saved) { isSaved = saved; }
+
+    /**
+     * 캘린더 표시에 사용할 대표 날짜 문자열을 반환합니다.
+     * 우선순위: eventStartDate > eventDate > eventEndDate
+     */
+    @Ignore
+    public String getCalendarAnchorDate() {
+        if (!TextUtils.isEmpty(eventStartDate)) {
+            return eventStartDate;
+        }
+        if (!TextUtils.isEmpty(eventDate)) {
+            return eventDate;
+        }
+        return eventEndDate;
+    }
+
+    // ... Parcelable implementation ...
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(id);
@@ -113,6 +178,7 @@ public class Post implements Serializable, Parcelable {
         dest.writeString(categoryName);
         dest.writeString(siteName);
         dest.writeByte((byte) (isNew == null ? 0 : isNew ? 1 : 2));
+        dest.writeByte((byte) (isSaved ? 1 : 0));
     }
 
     @Override

--- a/app/src/main/java/com/example/mobile_android/network/ApiService.java
+++ b/app/src/main/java/com/example/mobile_android/network/ApiService.java
@@ -28,7 +28,7 @@ public interface ApiService {
     Call<SiteRegisterResponse> registerSite(@Body SiteRegisterRequest request);
 
     // 📌 추가: 등록한 사이트 전체 불러오기
-    @GET("/api/v1/sites")
+    @GET("/api/v1/sites/")
     Call<List<Site>> getSites();
     @DELETE("/api/v1/sites/{siteId}")
     Call<Void> deleteSite(@Path("siteId") String siteId);

--- a/app/src/main/java/com/example/mobile_android/network/ApiService.java
+++ b/app/src/main/java/com/example/mobile_android/network/ApiService.java
@@ -28,7 +28,7 @@ public interface ApiService {
     Call<SiteRegisterResponse> registerSite(@Body SiteRegisterRequest request);
 
     // 📌 추가: 등록한 사이트 전체 불러오기
-    @GET("/api/v1/sites/")
+    @GET("/api/v1/sites")
     Call<List<Site>> getSites();
     @DELETE("/api/v1/sites/{siteId}")
     Call<Void> deleteSite(@Path("siteId") String siteId);

--- a/app/src/main/java/com/example/mobile_android/ui/calendar/CalendarFragment.java
+++ b/app/src/main/java/com/example/mobile_android/ui/calendar/CalendarFragment.java
@@ -4,36 +4,38 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageButton;
-import android.widget.TextView;
-import android.widget.Toast;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.GridLayoutManager;
-
-import com.example.mobile_android.R;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import com.example.mobile_android.data.local.AppDatabase;
+import com.example.mobile_android.data.local.PostDao;
 import com.example.mobile_android.databinding.FragmentCalendarBinding;
+import com.example.mobile_android.model.Post;
 import com.example.mobile_android.util.DateTimeUtils;
-
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 public class CalendarFragment extends Fragment {
 
     private FragmentCalendarBinding binding;
     private LocalDate selectedDate;
     private DayAdapter dayAdapter;
+    private EventListAdapter eventListAdapter;
+    private PostDao postDao;
+    private List<Post> allSavedPosts = new ArrayList<>();
 
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         binding = FragmentCalendarBinding.inflate(inflater, container, false);
+        postDao = AppDatabase.getInstance(requireContext()).postDao();
         return binding.getRoot();
     }
 
@@ -41,21 +43,14 @@ public class CalendarFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        // 날짜/어댑터 준비
         selectedDate = LocalDate.now(DateTimeUtils.getKstZoneId());
 
-        dayAdapter = new DayAdapter(day -> {
-            selectedDate = day;
-            dayAdapter.setSelected(selectedDate);
-        }, selectedDate);
+        setupCalendarView();
+        setupEventListView();
+        observeSavedPosts();
 
-        binding.rvDays.setLayoutManager(new GridLayoutManager(getContext(), 7));
-        binding.rvDays.setAdapter(dayAdapter);
-
-        // 첫 렌더링
         refreshMonth();
 
-        // 이전/다음 달
         binding.btnPrev.setOnClickListener(v -> {
             selectedDate = selectedDate.minusMonths(1);
             refreshMonth();
@@ -67,6 +62,48 @@ public class CalendarFragment extends Fragment {
         });
     }
 
+    private void setupCalendarView() {
+        dayAdapter = new DayAdapter(day -> {
+            selectedDate = day;
+            dayAdapter.setSelected(selectedDate);
+            filterEventsForSelectedDate();
+        }, selectedDate);
+
+        binding.rvDays.setLayoutManager(new GridLayoutManager(getContext(), 7));
+        binding.rvDays.setAdapter(dayAdapter);
+    }
+
+    private void setupEventListView() {
+        eventListAdapter = new EventListAdapter();
+        binding.rvEvents.setLayoutManager(new LinearLayoutManager(getContext()));
+        binding.rvEvents.setAdapter(eventListAdapter);
+    }
+
+    private void observeSavedPosts() {
+        postDao.getSavedPosts().observe(getViewLifecycleOwner(), posts -> {
+            allSavedPosts = posts;
+            // 이제 getCalendarAnchorDate()를 사용하여 대표 날짜를 가져옵니다.
+            List<LocalDate> eventDates = posts.stream()
+                    .map(post -> DateTimeUtils.parseServerDateToLocalDate(post.getCalendarAnchorDate()))
+                    .collect(Collectors.toList());
+            dayAdapter.setEventDates(eventDates);
+            filterEventsForSelectedDate();
+        });
+    }
+
+    private void filterEventsForSelectedDate() {
+        List<Post> eventsForDay = allSavedPosts.stream()
+                .filter(post -> {
+                    // 여기도 getCalendarAnchorDate()를 사용합니다.
+                    LocalDate eventDate = DateTimeUtils.parseServerDateToLocalDate(post.getCalendarAnchorDate());
+                    return eventDate != null && eventDate.equals(selectedDate);
+                })
+                .collect(Collectors.toList());
+        eventListAdapter.submitList(eventsForDay);
+
+        binding.tvNoEvents.setVisibility(eventsForDay.isEmpty() ? View.VISIBLE : View.GONE);
+    }
+
     private void refreshMonth() {
         DateTimeFormatter headerFmt = DateTimeFormatter.ofPattern("yyyy년 M월", Locale.KOREAN);
         binding.tvMonth.setText(selectedDate.format(headerFmt));
@@ -74,6 +111,7 @@ public class CalendarFragment extends Fragment {
         List<LocalDate> days = buildDaysOfMonthNoNulls(selectedDate);
         dayAdapter.submit(days);
         dayAdapter.setSelected(selectedDate);
+        filterEventsForSelectedDate();
     }
 
     private List<LocalDate> buildDaysOfMonthNoNulls(LocalDate base) {

--- a/app/src/main/java/com/example/mobile_android/ui/calendar/DayAdapter.java
+++ b/app/src/main/java/com/example/mobile_android/ui/calendar/DayAdapter.java
@@ -51,7 +51,7 @@ public class DayAdapter extends RecyclerView.Adapter<DayAdapter.DayViewHolder> {
         }
     }
 
-    public void setEventDates(List<LocalDate> eventDates) {
+    public void setEventDates(@NonNull List<LocalDate> eventDates) {
         this.eventDates = eventDates.stream().distinct().collect(Collectors.toList());
         notifyDataSetChanged();
     }

--- a/app/src/main/java/com/example/mobile_android/ui/calendar/DayAdapter.java
+++ b/app/src/main/java/com/example/mobile_android/ui/calendar/DayAdapter.java
@@ -9,57 +9,85 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import com.example.mobile_android.R;
 import java.time.LocalDate;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
-public class DayAdapter extends RecyclerView.Adapter<DayAdapter.VH> {
-    public interface OnDayClick { void onClick(LocalDate day); }
-    private final List<LocalDate> items = new ArrayList<>();
-    private final OnDayClick onDayClick;
-    private final LocalDate today;
-    private LocalDate monthAnchor;
-    private LocalDate selected;
+public class DayAdapter extends RecyclerView.Adapter<DayAdapter.DayViewHolder> {
 
-    public DayAdapter(OnDayClick onDayClick, LocalDate today) {
-        this.onDayClick = onDayClick;
-        this.today = today;
+    private final OnDayClickListener listener;
+    private List<LocalDate> days = Collections.emptyList();
+    private List<LocalDate> eventDates = Collections.emptyList();
+    private LocalDate selectedDate;
+
+    public interface OnDayClickListener {
+        void onDayClick(LocalDate date);
     }
 
-    public void submit(List<LocalDate> days) {
-        items.clear(); items.addAll(days);
-        if (!items.isEmpty()) monthAnchor = items.get(15);
+    public DayAdapter(OnDayClickListener listener, LocalDate selectedDate) {
+        this.listener = listener;
+        this.selectedDate = selectedDate;
+    }
+
+    public void submit(List<LocalDate> newDays) {
+        this.days = newDays;
         notifyDataSetChanged();
     }
-    public void setSelected(LocalDate selected) { this.selected = selected; notifyDataSetChanged(); }
 
-    @NonNull @Override public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_day, parent, false);
-        return new VH(v);
+    public void setSelected(LocalDate newSelectedDate) {
+        LocalDate oldSelectedDate = this.selectedDate;
+        this.selectedDate = newSelectedDate;
+        days.indexOf(oldSelectedDate);
+        notifyItemChanged(days.indexOf(oldSelectedDate));
+        notifyItemChanged(days.indexOf(newSelectedDate));
     }
 
-    @Override public void onBindViewHolder(@NonNull VH h, int position) {
-        LocalDate d = items.get(position);
-        boolean inMonth = d.getMonth() == monthAnchor.getMonth();
-        boolean isToday = d.equals(today);
-        boolean isSelected = selected != null && d.equals(selected);
+    public void setEventDates(List<LocalDate> eventDates) {
+        this.eventDates = eventDates.stream().distinct().collect(Collectors.toList());
+        notifyDataSetChanged();
+    }
 
-        h.tv.setText(String.valueOf(d.getDayOfMonth()));
-        if (isSelected) {
-            h.tv.setBackgroundResource(R.drawable.bg_day_selected);
-            h.tv.setTextColor(Color.parseColor("#1A73E8"));
-        } else if (isToday && inMonth) {
-            h.tv.setBackgroundResource(R.drawable.bg_day_today);
-            h.tv.setTextColor(Color.parseColor("#1A73E8"));
-        } else {
-            h.tv.setBackgroundResource(android.R.color.transparent);
-            h.tv.setTextColor(inMonth ? Color.parseColor("#202124") : Color.parseColor("#BDC1C6"));
+    @NonNull
+    @Override
+    public DayViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_day, parent, false);
+        return new DayViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull DayViewHolder holder, int position) {
+        holder.bind(days.get(position), listener, selectedDate, eventDates.contains(days.get(position)));
+    }
+
+    @Override
+    public int getItemCount() {
+        return days.size();
+    }
+
+    static class DayViewHolder extends RecyclerView.ViewHolder {
+        private final TextView tvDay;
+        private final View eventIndicator;
+
+        public DayViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvDay = itemView.findViewById(R.id.tv_day);
+            eventIndicator = itemView.findViewById(R.id.event_indicator);
         }
-        h.itemView.setOnClickListener(v -> { if (inMonth) { selected = d; notifyDataSetChanged(); onDayClick.onClick(d);} });
-    }
 
-    @Override public int getItemCount() { return items.size(); }
+        public void bind(LocalDate date, OnDayClickListener listener, LocalDate selectedDate, boolean hasEvent) {
+            tvDay.setText(String.valueOf(date.getDayOfMonth()));
 
-    static class VH extends RecyclerView.ViewHolder {
-        TextView tv; VH(@NonNull View itemView) { super(itemView); tv = itemView.findViewById(R.id.tvDay); }
+            if (date.equals(selectedDate)) {
+                itemView.setBackgroundResource(R.drawable.bg_day_selected);
+                tvDay.setTextColor(Color.WHITE);
+            } else {
+                itemView.setBackgroundResource(0);
+                tvDay.setTextColor(Color.BLACK);
+            }
+
+            eventIndicator.setVisibility(hasEvent ? View.VISIBLE : View.GONE);
+
+            itemView.setOnClickListener(v -> listener.onDayClick(date));
+        }
     }
 }

--- a/app/src/main/java/com/example/mobile_android/ui/calendar/DayAdapter.java
+++ b/app/src/main/java/com/example/mobile_android/ui/calendar/DayAdapter.java
@@ -65,7 +65,8 @@ public class DayAdapter extends RecyclerView.Adapter<DayAdapter.DayViewHolder> {
 
     @Override
     public void onBindViewHolder(@NonNull DayViewHolder holder, int position) {
-        holder.bind(days.get(position), listener, selectedDate, eventDates.contains(days.get(position)));
+        LocalDate date = days.get(position);
+        holder.bind(date, listener, selectedDate, eventDates.contains(date));
     }
 
     @Override

--- a/app/src/main/java/com/example/mobile_android/ui/calendar/DayAdapter.java
+++ b/app/src/main/java/com/example/mobile_android/ui/calendar/DayAdapter.java
@@ -37,9 +37,18 @@ public class DayAdapter extends RecyclerView.Adapter<DayAdapter.DayViewHolder> {
     public void setSelected(LocalDate newSelectedDate) {
         LocalDate oldSelectedDate = this.selectedDate;
         this.selectedDate = newSelectedDate;
-        days.indexOf(oldSelectedDate);
-        notifyItemChanged(days.indexOf(oldSelectedDate));
-        notifyItemChanged(days.indexOf(newSelectedDate));
+
+        // 기존 선택된 날짜의 인덱스를 안전하게 확인
+        int oldIndex = days.indexOf(oldSelectedDate);
+        if (oldIndex >= 0) {
+            notifyItemChanged(oldIndex);
+        }
+
+        // 새로 선택된 날짜의 인덱스를 안전하게 확인
+        int newIndex = days.indexOf(newSelectedDate);
+        if (newIndex >= 0) {
+            notifyItemChanged(newIndex);
+        }
     }
 
     public void setEventDates(List<LocalDate> eventDates) {

--- a/app/src/main/java/com/example/mobile_android/ui/calendar/EventListAdapter.java
+++ b/app/src/main/java/com/example/mobile_android/ui/calendar/EventListAdapter.java
@@ -1,0 +1,77 @@
+package com.example.mobile_android.ui.calendar;
+
+import android.content.Context;
+import android.content.Intent;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.ListAdapter;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.mobile_android.R;
+import com.example.mobile_android.model.Post;
+import com.example.mobile_android.ui.post.PostDetailActivity;
+import com.example.mobile_android.util.DateTimeUtils;
+
+public class EventListAdapter extends ListAdapter<Post, EventListAdapter.EventViewHolder> {
+
+    public EventListAdapter() {
+        super(new DiffUtil.ItemCallback<Post>() {
+            @Override
+            public boolean areItemsTheSame(@NonNull Post oldItem, @NonNull Post newItem) {
+                return oldItem.getId().equals(newItem.getId());
+            }
+
+            @Override
+            public boolean areContentsTheSame(@NonNull Post oldItem, @NonNull Post newItem) {
+                return oldItem.isSaved() == newItem.isSaved() && oldItem.getTitle().equals(newItem.getTitle());
+            }
+        });
+    }
+
+    @NonNull
+    @Override
+    public EventViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_calendar_event, parent, false);
+        return new EventViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull EventViewHolder holder, int position) {
+        Post post = getItem(position);
+        holder.bind(post);
+    }
+
+    static class EventViewHolder extends RecyclerView.ViewHolder {
+        private final TextView tvEventTitle;
+        private final TextView tvEventTime;
+
+        public EventViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvEventTitle = itemView.findViewById(R.id.tv_event_title);
+            tvEventTime = itemView.findViewById(R.id.tv_event_time);
+        }
+
+        public void bind(Post post) {
+            tvEventTitle.setText(post.getTitle());
+
+            String time = DateTimeUtils.formatServerDate(post.getEventStartDate(), "HH:mm");
+            if (TextUtils.isEmpty(time)) {
+                time = DateTimeUtils.formatServerDate(post.getEventDate(), "HH:mm");
+            }
+            tvEventTime.setText(time);
+
+            itemView.setOnClickListener(v -> {
+                Context context = itemView.getContext();
+                Intent intent = new Intent(context, PostDetailActivity.class);
+                intent.putExtra("POST_ID", post.getId());
+                context.startActivity(intent);
+            });
+        }
+    }
+}

--- a/app/src/main/java/com/example/mobile_android/ui/post/PostAdapter.java
+++ b/app/src/main/java/com/example/mobile_android/ui/post/PostAdapter.java
@@ -13,20 +13,24 @@ import androidx.appcompat.widget.SwitchCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.mobile_android.R;
+import com.example.mobile_android.data.local.AppDatabase;
+import com.example.mobile_android.data.local.PostDao;
 import com.example.mobile_android.model.Post;
-import com.example.mobile_android.util.CalendarManager;
 import com.example.mobile_android.util.DateTimeUtils;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class PostAdapter extends RecyclerView.Adapter<PostAdapter.PostViewHolder> {
 
     private final Context context;
     private final List<Post> postList;
-    private final CalendarManager calendarManager;
+    private final PostDao postDao;
+    private final ExecutorService databaseExecutor = Executors.newSingleThreadExecutor();
     private OnPostClickListener listener;
 
     public interface OnPostClickListener {
@@ -36,7 +40,7 @@ public class PostAdapter extends RecyclerView.Adapter<PostAdapter.PostViewHolder
     public PostAdapter(Context context, List<Post> postList) {
         this.context = context;
         this.postList = postList;
-        this.calendarManager = new CalendarManager(context);
+        this.postDao = AppDatabase.getInstance(context).postDao();
     }
 
     public void setOnPostClickListener(OnPostClickListener listener) {
@@ -84,18 +88,14 @@ public class PostAdapter extends RecyclerView.Adapter<PostAdapter.PostViewHolder
         String calendarAnchor = resolveCalendarAnchor(post);
         if (!TextUtils.isEmpty(calendarAnchor)) {
             holder.switchCalendar.setEnabled(true);
-            holder.switchCalendar.setChecked(calendarManager.isEventRegistered(post.getId()));
+            // 이제 데이터베이스의 isSaved 필드를 사용해 토글 상태를 결정
+            holder.switchCalendar.setChecked(post.isSaved());
             holder.switchCalendar.setOnCheckedChangeListener((buttonView, isChecked) -> {
-                if (isChecked) {
-                    calendarManager.addEventToCalendar(
-                            post.getId(),
-                            post.getTitle(),
-                            calendarAnchor,
-                            post.getLocation()
-                    );
-                } else {
-                    calendarManager.removeEventFromCalendar(post.getId());
-                }
+                // UI를 즉시 업데이트하고, DB 작업은 백그라운드에서 처리
+                post.setSaved(isChecked);
+                databaseExecutor.execute(() -> {
+                    postDao.updateSaveState(post.getId(), isChecked);
+                });
             });
         } else {
             holder.switchCalendar.setEnabled(false);

--- a/app/src/main/java/com/example/mobile_android/ui/post/PostDetailActivity.java
+++ b/app/src/main/java/com/example/mobile_android/ui/post/PostDetailActivity.java
@@ -1,8 +1,6 @@
 package com.example.mobile_android.ui.post;
 
-import android.Manifest;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -14,23 +12,19 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.lifecycle.LiveData;
 
 import com.example.mobile_android.R;
+import com.example.mobile_android.data.local.AppDatabase;
+import com.example.mobile_android.data.local.PostDao;
 import com.example.mobile_android.model.Post;
-import com.example.mobile_android.network.ApiClient;
-import com.example.mobile_android.network.ApiService;
-import com.example.mobile_android.util.CalendarManager;
 import com.example.mobile_android.util.DateTimeUtils;
 
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class PostDetailActivity extends AppCompatActivity {
-
-    private static final int REQUEST_CALENDAR_PERMISSION = 1001;
 
     private TextView tvPostTitle;
     private TextView tvPostCategory;
@@ -44,9 +38,11 @@ public class PostDetailActivity extends AppCompatActivity {
     private Button btnAddToCalendar;
     private ImageButton btnBack;
 
-    private ApiService apiService;
-    private CalendarManager calendarManager;
+    private PostDao postDao;
+    private ExecutorService databaseExecutor;
+    private LiveData<Post> postLiveData;
     private Post currentPost;
+    private String postId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -54,12 +50,11 @@ public class PostDetailActivity extends AppCompatActivity {
         setContentView(R.layout.activity_post_detail);
 
         initViews();
-        calendarManager = new CalendarManager(this);
-        apiService = ApiClient.getClient().create(ApiService.class);
+        initDatabase();
 
-        String postId = getIntent().getStringExtra("POST_ID");
+        postId = getIntent().getStringExtra("POST_ID");
         if (postId != null) {
-            loadPostDetail(postId);
+            observePost();
         } else {
             Toast.makeText(this, "게시물 ID가 없습니다.", Toast.LENGTH_SHORT).show();
             finish();
@@ -82,6 +77,21 @@ public class PostDetailActivity extends AppCompatActivity {
         btnBack = findViewById(R.id.btn_back);
     }
 
+    private void initDatabase() {
+        postDao = AppDatabase.getInstance(this).postDao();
+        databaseExecutor = Executors.newSingleThreadExecutor();
+    }
+
+    private void observePost() {
+        postLiveData = postDao.getPostById(postId);
+        postLiveData.observe(this, post -> {
+            if (post != null) {
+                currentPost = post;
+                displayPostDetail(post);
+            }
+        });
+    }
+
     private void setupClickListeners() {
         btnBack.setOnClickListener(v -> finish());
 
@@ -94,42 +104,16 @@ public class PostDetailActivity extends AppCompatActivity {
         btnAddToCalendar.setOnClickListener(v -> handleCalendarToggle());
     }
 
-    private void loadPostDetail(String postId) {
-        Call<Post> call = apiService.getPostDetail(postId);
-        call.enqueue(new Callback<Post>() {
-            @Override
-            public void onResponse(@NonNull Call<Post> call, @NonNull Response<Post> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    currentPost = response.body();
-                    displayPostDetail(currentPost);
-                } else {
-                    Toast.makeText(PostDetailActivity.this,
-                            "게시물을 불러오지 못했습니다. (" + response.code() + ")",
-                            Toast.LENGTH_LONG).show();
-                    finish();
-                }
-            }
-
-            @Override
-            public void onFailure(@NonNull Call<Post> call, @NonNull Throwable t) {
-                Toast.makeText(PostDetailActivity.this,
-                        "네트워크 오류: " + t.getMessage(),
-                        Toast.LENGTH_LONG).show();
-                finish();
-            }
-        });
-    }
-
     private void displayPostDetail(Post post) {
         tvPostTitle.setText(post.getTitle());
         tvPostCategory.setText(resolveCategory(post));
         tvPostContent.setText(post.getContent());
-
         tvPostCreatedAt.setText(formatDateTime(post.getCreatedAt(), "yyyy년 MM월 dd일 a hh:mm"));
 
         bindEventSection(post);
         bindLocation(post);
         bindSource(post);
+        updateCalendarButtonUI(post.isSaved());
     }
 
     private void bindEventSection(Post post) {
@@ -138,14 +122,12 @@ public class PostDetailActivity extends AppCompatActivity {
             tvPostEventDate.setVisibility(View.GONE);
             tvCalendarInfo.setVisibility(View.GONE);
             btnAddToCalendar.setVisibility(View.GONE);
-            return;
+        } else {
+            tvPostEventDate.setVisibility(View.VISIBLE);
+            tvPostEventDate.setText("📅 " + eventLabel);
+            tvCalendarInfo.setVisibility(View.VISIBLE);
+            btnAddToCalendar.setVisibility(View.VISIBLE);
         }
-
-        tvPostEventDate.setVisibility(View.VISIBLE);
-        tvPostEventDate.setText("📅 " + eventLabel);
-        tvCalendarInfo.setVisibility(View.VISIBLE);
-        btnAddToCalendar.setVisibility(View.VISIBLE);
-        updateCalendarButtonText();
     }
 
     private void bindLocation(Post post) {
@@ -171,66 +153,19 @@ public class PostDetailActivity extends AppCompatActivity {
         if (currentPost == null) {
             return;
         }
-
-        String calendarAnchor = resolveCalendarAnchor(currentPost);
-        if (TextUtils.isEmpty(calendarAnchor)) {
-            Toast.makeText(this, "등록 가능한 이벤트 날짜가 없습니다.", Toast.LENGTH_SHORT).show();
-            return;
-        }
-
-        if (!calendarManager.hasCalendarPermission()) {
-            requestCalendarPermission();
-            return;
-        }
-
-        if (calendarManager.isEventRegistered(currentPost.getId())) {
-            calendarManager.removeEventFromCalendar(currentPost.getId());
-        } else {
-            calendarManager.addEventToCalendar(
-                    currentPost.getId(),
-                    currentPost.getTitle(),
-                    calendarAnchor,
-                    currentPost.getLocation()
-            );
-        }
-        updateCalendarButtonText();
+        boolean newState = !currentPost.isSaved();
+        databaseExecutor.execute(() -> {
+            postDao.updateSaveState(currentPost.getId(), newState);
+        });
     }
 
-    private void updateCalendarButtonText() {
-        if (currentPost != null && calendarManager.isEventRegistered(currentPost.getId())) {
+    private void updateCalendarButtonUI(boolean isSaved) {
+        if (isSaved) {
             btnAddToCalendar.setText("캘린더에서 삭제");
-            btnAddToCalendar.setBackgroundTintList(
-                    ContextCompat.getColorStateList(this, android.R.color.holo_red_light)
-            );
+            btnAddToCalendar.setBackgroundColor(ContextCompat.getColor(this, android.R.color.holo_red_light));
         } else {
             btnAddToCalendar.setText("캘린더에 추가");
-            btnAddToCalendar.setBackgroundTintList(
-                    ContextCompat.getColorStateList(this, android.R.color.holo_purple)
-            );
-        }
-    }
-
-    private void requestCalendarPermission() {
-        ActivityCompat.requestPermissions(
-                this,
-                new String[]{
-                        Manifest.permission.READ_CALENDAR,
-                        Manifest.permission.WRITE_CALENDAR
-                },
-                REQUEST_CALENDAR_PERMISSION
-        );
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == REQUEST_CALENDAR_PERMISSION) {
-            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                handleCalendarToggle();
-            } else {
-                Toast.makeText(this, "캘린더 권한이 필요합니다.", Toast.LENGTH_SHORT).show();
-            }
+            btnAddToCalendar.setBackgroundColor(ContextCompat.getColor(this, android.R.color.holo_purple));
         }
     }
 
@@ -241,40 +176,17 @@ public class PostDetailActivity extends AppCompatActivity {
     private String resolveCategory(Post post) {
         if (!TextUtils.isEmpty(post.getCategoryName())) {
             return post.getCategoryName();
-        }
-        if (!TextUtils.isEmpty(post.getSiteName())) {
+        } else if (!TextUtils.isEmpty(post.getSiteName())) {
             return post.getSiteName();
         }
         return getString(R.string.app_name);
     }
 
     private String buildEventLabel(Post post) {
-        String start = formatDateTime(post.getEventStartDate(), "yyyy년 MM월 dd일 (E) HH:mm");
-        String end = formatDateTime(post.getEventEndDate(), "yyyy년 MM월 dd일 (E) HH:mm");
-        String single = formatDateTime(post.getEventDate(), "yyyy년 MM월 dd일 (E) HH:mm");
-
-        if (!TextUtils.isEmpty(start) && !TextUtils.isEmpty(end)) {
-            return start + " ~ " + end;
+        String eventDateStr = post.getCalendarAnchorDate();
+        if (TextUtils.isEmpty(eventDateStr)) {
+            return "";
         }
-        if (!TextUtils.isEmpty(start)) {
-            return start;
-        }
-        if (!TextUtils.isEmpty(single)) {
-            return single;
-        }
-        return end;
-    }
-
-    private String resolveCalendarAnchor(Post post) {
-        if (!TextUtils.isEmpty(post.getEventStartDate())) {
-            return post.getEventStartDate();
-        }
-        if (!TextUtils.isEmpty(post.getEventDate())) {
-            return post.getEventDate();
-        }
-        if (!TextUtils.isEmpty(post.getEventEndDate())) {
-            return post.getEventEndDate();
-        }
-        return null;
+        return formatDateTime(eventDateStr, "yyyy년 MM월 dd일 (E) HH:mm");
     }
 }

--- a/app/src/main/java/com/example/mobile_android/ui/post/PostListActivity.java
+++ b/app/src/main/java/com/example/mobile_android/ui/post/PostListActivity.java
@@ -2,13 +2,15 @@ package com.example.mobile_android.ui.post;
 
 import android.os.Bundle;
 import android.widget.Toast;
-import android.util.Log;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.LiveData;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.mobile_android.R;
+import com.example.mobile_android.data.local.AppDatabase;
+import com.example.mobile_android.data.local.PostDao;
 import com.example.mobile_android.model.Post;
 import com.example.mobile_android.model.PostListResponse;
 import com.example.mobile_android.network.ApiClient;
@@ -16,6 +18,8 @@ import com.example.mobile_android.network.ApiService;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -25,8 +29,10 @@ public class PostListActivity extends AppCompatActivity {
 
     private RecyclerView recyclerView;
     private PostAdapter postAdapter;
-    private List<Post> postList;
+    private List<Post> currentPostList = new ArrayList<>();
     private ApiService apiService;
+    private PostDao postDao;
+    private ExecutorService databaseExecutor;
     private String siteId;
 
     @Override
@@ -34,12 +40,28 @@ public class PostListActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_post_list);
 
+        initDatabase();
         apiService = ApiClient.getClient().create(ApiService.class);
 
         // Intent에서 사이트 정보 가져오기
         String siteName = getIntent().getStringExtra("SITE_NAME");
         siteId = getIntent().getStringExtra("SITE_ID");
 
+        setupToolbar(siteName);
+        setupRecyclerView();
+
+        if (siteId != null) {
+            observePostsBySite();
+            loadPostsFromServer();
+        }
+    }
+
+    private void initDatabase() {
+        postDao = AppDatabase.getInstance(this).postDao();
+        databaseExecutor = Executors.newSingleThreadExecutor();
+    }
+
+    private void setupToolbar(String siteName) {
         if (siteName != null) {
             if (getSupportActionBar() != null) {
                 getSupportActionBar().setTitle(siteName);
@@ -49,67 +71,47 @@ public class PostListActivity extends AppCompatActivity {
                 setTitle(siteName);
             }
         }
-
-        recyclerView = findViewById(R.id.postRecyclerView);
-        recyclerView.setLayoutManager(new LinearLayoutManager(this));
-
-        // 초기 데이터는 Intent에서 가져오기 (있다면)
-        postList = getIntent().getParcelableArrayListExtra("posts");
-        if (postList == null) {
-            postList = new ArrayList<>();
-        }
-      
-        postAdapter = new PostAdapter(this, postList);
-        recyclerView.setAdapter(postAdapter);
-
-        // API에서 최신 데이터 로드
-        if (siteId != null) {
-            loadPosts();
-        }
     }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // 화면으로 돌아올 때마다 새로고침
-        if (siteId != null) {
-            loadPosts();
-        }
+    private void setupRecyclerView() {
+        recyclerView = findViewById(R.id.postRecyclerView);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        postAdapter = new PostAdapter(this, currentPostList);
+        recyclerView.setAdapter(postAdapter);
+    }
+
+    private void observePostsBySite() {
+        LiveData<List<Post>> postsLiveData = postDao.getPostsBySite(siteId);
+        postsLiveData.observe(this, posts -> {
+            currentPostList.clear();
+            currentPostList.addAll(posts);
+            postAdapter.notifyDataSetChanged();
+        });
+    }
+
+    private void loadPostsFromServer() {
+        Call<PostListResponse> call = apiService.getPosts(1, 100, null, siteId, null, null, "created_at", "desc");
+
+        call.enqueue(new Callback<PostListResponse>() {
+            @Override
+            public void onResponse(Call<PostListResponse> call, Response<PostListResponse> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    databaseExecutor.execute(() -> {
+                        postDao.upsert(response.body().getItems());
+                    });
+                }
+            }
+
+            @Override
+            public void onFailure(Call<PostListResponse> call, Throwable t) {
+                Toast.makeText(PostListActivity.this, "네트워크 오류: " + t.getMessage(), Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     @Override
     public boolean onSupportNavigateUp() {
         finish();
         return true;
-    }
-
-    private void loadPosts() {
-        Call<PostListResponse> call = apiService.getPosts(
-                1, // page
-                100, // page_size
-                null, // query
-                siteId, // site_id
-                null, // since
-                null, // until
-                "created_at", // order_by
-                "desc" // order
-        );
-
-        call.enqueue(new Callback<PostListResponse>() {
-            @Override
-            public void onResponse(Call<PostListResponse> call, Response<PostListResponse> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    postList.clear();
-                    postList.addAll(response.body().getItems());
-                    postAdapter.notifyDataSetChanged();
-                }
-            }
-
-            @Override
-            public void onFailure(Call<PostListResponse> call, Throwable t) {
-                Toast.makeText(PostListActivity.this,
-                        "네트워크 오류: " + t.getMessage(), Toast.LENGTH_SHORT).show();
-            }
-        });
     }
 }

--- a/app/src/main/java/com/example/mobile_android/ui/post/PostManagementFragment.java
+++ b/app/src/main/java/com/example/mobile_android/ui/post/PostManagementFragment.java
@@ -12,42 +12,45 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.cardview.widget.CardView;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.LiveData;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.mobile_android.R;
+import com.example.mobile_android.data.local.AppDatabase;
+import com.example.mobile_android.data.local.PostDao;
 import com.example.mobile_android.model.Post;
+import com.example.mobile_android.model.PostListResponse;
 import com.example.mobile_android.network.ApiClient;
 import com.example.mobile_android.network.ApiService;
 import com.google.android.material.tabs.TabLayout;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-/**
- * 게시물 관리 화면
- * - 전체 게시물 목록 조회
- * - 탭 필터링 (전체, 새 게시물, 저장됨)
- * - 검색 기능
- * - 캘린더 등록된 게시물 표시
- */
 public class PostManagementFragment extends Fragment {
 
     private RecyclerView recyclerView;
     private PostAdapter adapter;
-    private List<Post> postList = new ArrayList<>();
-    private List<Post> filteredList = new ArrayList<>();
+    private List<Post> currentPostList = new ArrayList<>(); // 어댑터에 공급할 현재 리스트
 
     private TabLayout tabLayout;
     private EditText etSearch;
     private CardView cardCalendarInfo;
 
     private ApiService apiService;
+    private PostDao postDao;
+    private ExecutorService databaseExecutor;
     private String currentFilter = "all";
+
+    private LiveData<List<Post>> allPostsLiveData;
+    private LiveData<List<Post>> savedPostsLiveData;
 
     @Nullable
     @Override
@@ -63,7 +66,8 @@ public class PostManagementFragment extends Fragment {
         setupRecyclerView();
         setupTabLayout();
         setupClickListeners();
-        loadPosts();
+        loadPostsFromServer();
+        observeDatabase();
     }
 
     private void initViews(View view) {
@@ -73,10 +77,15 @@ public class PostManagementFragment extends Fragment {
         cardCalendarInfo = view.findViewById(R.id.card_calendar_info);
 
         apiService = ApiClient.getClient().create(ApiService.class);
+        postDao = AppDatabase.getInstance(requireContext()).postDao();
+        databaseExecutor = Executors.newSingleThreadExecutor();
+
+        allPostsLiveData = postDao.getAllPosts();
+        savedPostsLiveData = postDao.getSavedPosts();
     }
 
     private void setupRecyclerView() {
-        adapter = new PostAdapter(requireContext(), filteredList);
+        adapter = new PostAdapter(requireContext(), currentPostList);
         recyclerView.setLayoutManager(new LinearLayoutManager(requireContext()));
         recyclerView.setAdapter(adapter);
 
@@ -95,23 +104,55 @@ public class PostManagementFragment extends Fragment {
                 switch (position) {
                     case 0:
                         currentFilter = "all";
+                        allPostsLiveData.observe(getViewLifecycleOwner(), PostManagementFragment.this::updateAdapter);
                         break;
                     case 1:
                         currentFilter = "new";
+                        // 'new' 필터링 로직은 getAllPosts() 결과에서 처리 가능하므로 별도 LiveData 불필요
+                        allPostsLiveData.observe(getViewLifecycleOwner(), PostManagementFragment.this::updateAdapter);
                         break;
                     case 2:
                         currentFilter = "saved";
+                        savedPostsLiveData.observe(getViewLifecycleOwner(), PostManagementFragment.this::updateAdapter);
                         break;
                 }
-                filterPosts();
             }
 
             @Override
-            public void onTabUnselected(TabLayout.Tab tab) {}
+            public void onTabUnselected(TabLayout.Tab tab) { }
 
             @Override
-            public void onTabReselected(TabLayout.Tab tab) {}
+            public void onTabReselected(TabLayout.Tab tab) { }
         });
+    }
+
+    private void observeDatabase() {
+        // 초기 탭("all")에 대한 관찰 시작
+        allPostsLiveData.observe(getViewLifecycleOwner(), this::updateAdapter);
+
+        // 저장된 게시물 개수 관찰
+        savedPostsLiveData.observe(getViewLifecycleOwner(), savedPosts -> {
+            if (savedPosts.size() > 0) {
+                cardCalendarInfo.setVisibility(View.VISIBLE);
+            } else {
+                cardCalendarInfo.setVisibility(View.GONE);
+            }
+        });
+    }
+
+    private void updateAdapter(List<Post> posts) {
+        currentPostList.clear();
+        if ("new".equals(currentFilter)) {
+             // 24시간 이내 게시물 필터링 (isNew 필드 또는 createdAt 기준)
+            for (Post post : posts) {
+                if (post.getIsNew() != null && post.getIsNew()) {
+                    currentPostList.add(post);
+                }
+            }
+        } else {
+            currentPostList.addAll(posts);
+        }
+        adapter.notifyDataSetChanged();
     }
 
     private void setupClickListeners() {
@@ -122,74 +163,24 @@ public class PostManagementFragment extends Fragment {
         }
     }
 
-    private void loadPosts() {
-        // 모든 게시물 조회
-        Call<com.example.mobile_android.model.PostListResponse> call = apiService.getPosts(
-                1, 100, null, null, null, null, "created_at", "desc"
-        );
+    private void loadPostsFromServer() {
+        Call<PostListResponse> call = apiService.getPosts(1, 100, null, null, null, null, "created_at", "desc");
 
-        call.enqueue(new Callback<com.example.mobile_android.model.PostListResponse>() {
+        call.enqueue(new Callback<PostListResponse>() {
             @Override
-            public void onResponse(Call<com.example.mobile_android.model.PostListResponse> call,
-                                   Response<com.example.mobile_android.model.PostListResponse> response) {
+            public void onResponse(Call<PostListResponse> call, Response<PostListResponse> response) {
                 if (response.isSuccessful() && response.body() != null) {
-                    postList.clear();
-                    postList.addAll(response.body().getItems());
-                    filterPosts();
-                    updateCalendarInfo();
+                    // 서버에서 받은 데이터를 DB에 upsert
+                    databaseExecutor.execute(() -> {
+                        postDao.upsert(response.body().getItems());
+                    });
                 }
             }
 
             @Override
-            public void onFailure(Call<com.example.mobile_android.model.PostListResponse> call, Throwable t) {
-                Toast.makeText(requireContext(), "게시물 불러오기 실패: " + t.getMessage(),
-                        Toast.LENGTH_SHORT).show();
+            public void onFailure(Call<PostListResponse> call, Throwable t) {
+                Toast.makeText(requireContext(), "게시물 불러오기 실패: " + t.getMessage(), Toast.LENGTH_SHORT).show();
             }
         });
     }
-
-    private void filterPosts() {
-        filteredList.clear();
-
-        if ("all".equals(currentFilter)) {
-            filteredList.addAll(postList);
-        } else if ("new".equals(currentFilter)) {
-            // 24시간 이내 게시물
-            long dayAgo = System.currentTimeMillis() - (24 * 60 * 60 * 1000);
-            for (Post post : postList) {
-                // TODO: created_at 파싱하여 필터링
-                filteredList.add(post);
-            }
-        } else if ("saved".equals(currentFilter)) {
-            // 저장된 게시물 (캘린더 등록된 게시물)
-            // TODO: SharedPreferences에서 저장된 게시물 확인
-        }
-
-        adapter.notifyDataSetChanged();
-    }
-
-    private void updateCalendarInfo() {
-        // 캘린더 등록된 게시물 개수 확인
-        int calendarCount = 0;
-        // TODO: 캘린더 등록된 게시물 개수 계산
-
-        if (calendarCount > 0) {
-            cardCalendarInfo.setVisibility(View.VISIBLE);
-        } else {
-            cardCalendarInfo.setVisibility(View.GONE);
-        }
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        // 화면으로 돌아올 때 목록 새로고침
-        if (!postList.isEmpty()) {
-            filterPosts();
-            updateCalendarInfo();
-        }
-    }
 }
-
-
-

--- a/app/src/main/java/com/example/mobile_android/ui/search/TagChipAdapter.java
+++ b/app/src/main/java/com/example/mobile_android/ui/search/TagChipAdapter.java
@@ -47,14 +47,19 @@ public class TagChipAdapter extends RecyclerView.Adapter<TagChipAdapter.VH> {
         h.tvCount.setSelected(it.selected);
 
         h.root.setOnClickListener(v -> {
-            if (selectedPos != RecyclerView.NO_POSITION && selectedPos != position) {
+            int currentPosition = h.getAdapterPosition();
+            if (currentPosition == RecyclerView.NO_POSITION) {
+                return;
+            }
+            
+            if (selectedPos != RecyclerView.NO_POSITION && selectedPos != currentPosition) {
                 items.get(selectedPos).selected = false;
                 notifyItemChanged(selectedPos);
             }
             it.selected = true;
-            notifyItemChanged(position);
-            selectedPos = position;
-            if (listener != null) listener.onClick(position, it);
+            notifyItemChanged(currentPosition);
+            selectedPos = currentPosition;
+            if (listener != null) listener.onClick(currentPosition, it);
         });
     }
 

--- a/app/src/main/java/com/example/mobile_android/util/DateTimeUtils.java
+++ b/app/src/main/java/com/example/mobile_android/util/DateTimeUtils.java
@@ -1,7 +1,9 @@
 package com.example.mobile_android.util;
 
+import android.text.TextUtils;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.Locale;
@@ -14,7 +16,14 @@ import java.util.TimeZone;
  */
 public final class DateTimeUtils {
 
-    private static final String DEFAULT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
+    // 서버에서 내려올 수 있는 날짜 형식들을 순서대로 정의
+    private static final String[] SERVER_DATE_PATTERNS = {
+            "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd HH:mm:ss"
+    };
+
     private static final TimeZone KST_TIME_ZONE = TimeZone.getTimeZone("Asia/Seoul");
     private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
     private static final Locale KOREA = Locale.KOREA;
@@ -23,19 +32,27 @@ public final class DateTimeUtils {
 
     private static SimpleDateFormat formatter(String pattern) {
         SimpleDateFormat sdf = new SimpleDateFormat(pattern, KOREA);
-        sdf.setTimeZone(KST_TIME_ZONE);
+        // 'Z'가 포함된 패턴은 UTC(Zulu)로 해석해야 하므로, KST를 강제하지 않음
+        if (!pattern.endsWith("'Z'")) {
+            sdf.setTimeZone(KST_TIME_ZONE);
+        }
         return sdf;
     }
 
     public static Date parseServerDate(String dateTimeStr) {
-        if (dateTimeStr == null || dateTimeStr.isEmpty()) {
+        if (TextUtils.isEmpty(dateTimeStr)) {
             return null;
         }
-        try {
-            return formatter(DEFAULT_PATTERN).parse(dateTimeStr);
-        } catch (ParseException e) {
-            return null;
+        // 정의된 모든 패턴을 순서대로 시도
+        for (String pattern : SERVER_DATE_PATTERNS) {
+            try {
+                return formatter(pattern).parse(dateTimeStr);
+            } catch (ParseException e) {
+                // 현재 패턴 실패 시, 다음 패턴으로 계속 진행
+            }
         }
+        // 모든 패턴 실패 시 null 반환
+        return null;
     }
 
     public static String formatServerDate(String dateTimeStr, String pattern) {
@@ -43,7 +60,21 @@ public final class DateTimeUtils {
         if (date == null) {
             return "";
         }
-        return formatter(pattern).format(date);
+        // 출력은 항상 KST 기준으로 포맷
+        SimpleDateFormat outputFormatter = new SimpleDateFormat(pattern, KOREA);
+        outputFormatter.setTimeZone(KST_TIME_ZONE);
+        return outputFormatter.format(date);
+    }
+
+    public static LocalDate parseServerDateToLocalDate(String dateTimeStr) {
+        if (TextUtils.isEmpty(dateTimeStr)) {
+            return null;
+        }
+        Date date = parseServerDate(dateTimeStr);
+        if (date == null) {
+            return null;
+        }
+        return date.toInstant().atZone(KST_ZONE_ID).toLocalDate();
     }
 
     public static TimeZone getKstTimeZone() {

--- a/app/src/main/java/com/example/mobile_android/util/DateTimeUtils.java
+++ b/app/src/main/java/com/example/mobile_android/util/DateTimeUtils.java
@@ -24,6 +24,7 @@ public final class DateTimeUtils {
             "yyyy-MM-dd HH:mm:ss"
     };
 
+    private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
     private static final TimeZone KST_TIME_ZONE = TimeZone.getTimeZone("Asia/Seoul");
     private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
     private static final Locale KOREA = Locale.KOREA;
@@ -32,8 +33,11 @@ public final class DateTimeUtils {
 
     private static SimpleDateFormat formatter(String pattern) {
         SimpleDateFormat sdf = new SimpleDateFormat(pattern, KOREA);
-        // 'Z'가 포함된 패턴은 UTC(Zulu)로 해석해야 하므로, KST를 강제하지 않음
-        if (!pattern.endsWith("'Z'")) {
+        // 'Z'(Zulu)로 끝나는 패턴은 UTC 타임존으로 명시적으로 지정합니다.
+        if (pattern.endsWith("'Z'")) {
+            sdf.setTimeZone(UTC_TIME_ZONE);
+        } else {
+            // 그 외의 경우는 KST를 기준으로 해석합니다.
             sdf.setTimeZone(KST_TIME_ZONE);
         }
         return sdf;

--- a/app/src/main/res/drawable/bg_day_selected.xml
+++ b/app/src/main/res/drawable/bg_day_selected.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
-    <solid android:color="@android:color/holo_blue_light" />
-</shape>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="6dp"
+    android:insetTop="6dp"
+    android:insetRight="6dp"
+    android:insetBottom="6dp">
+    <shape android:shape="oval">
+        <solid android:color="@android:color/holo_blue_light" />
+    </shape>
+</inset>

--- a/app/src/main/res/drawable/bg_event_indicator.xml
+++ b/app/src/main/res/drawable/bg_event_indicator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="@android:color/holo_blue_light" />
+    <solid android:color="@android:color/holo_red_light" />
 </shape>

--- a/app/src/main/res/drawable/ic_chevron_left.xml
+++ b/app/src/main/res/drawable/ic_chevron_left.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M15.41,7.41L14,6l-6,6 6,6 1.41,-1.41L10.83,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_chevron_right.xml
+++ b/app/src/main/res/drawable/ic_chevron_right.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M8.59,16.59L10,18l6,-6 -6,-6 -1.41,1.41L13.17,12z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -1,87 +1,111 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
-    android:background="#F7F7F8"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ui.calendar.CalendarFragment">
 
+    <!-- Month Header -->
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
         android:padding="16dp">
 
-        <LinearLayout
-            android:orientation="vertical"
-            android:background="@android:color/white"
-            android:padding="12dp"
-            android:elevation="1dp"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+        <ImageButton
+            android:id="@+id/btn_prev"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_chevron_left" />
 
-            <!-- Month nav -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical"
-                android:paddingVertical="8dp"
-                android:layout_marginBottom="4dp">
+        <TextView
+            android:id="@+id/tv_month"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:textAppearance="@style/TextAppearance.AppCompat.Large"
+            tools:text="2025년 11월" />
 
-                <ImageButton
-                    android:id="@+id/btnPrev"
-                    android:layout_width="40dp"
-                    android:layout_height="40dp"
-                    android:background="@android:color/transparent"
-                    android:src="@drawable/outline_arrow_back_ios_24"
-                    android:contentDescription="이전 달" />
-
-                <TextView
-                    android:id="@+id/tvMonth"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="April 2025"
-                    android:textStyle="bold"
-                    android:textSize="16sp"
-                    android:textColor="#222" />
-
-                <ImageButton
-                    android:id="@+id/btnNext"
-                    android:layout_width="40dp"
-                    android:layout_height="40dp"
-                    android:background="@android:color/transparent"
-                    android:src="@drawable/outline_arrow_forward_ios_24"
-                    android:contentDescription="다음 달" />
-            </LinearLayout>
-
-            <!-- Week labels -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="6dp"
-                android:paddingBottom="6dp"
-                android:gravity="center"
-                android:weightSum="7">
-
-                <TextView style="@style/WeekLabel" android:text="SUN"/>
-                <TextView style="@style/WeekLabel" android:text="MON"/>
-                <TextView style="@style/WeekLabel" android:text="TUE"/>
-                <TextView style="@style/WeekLabel" android:text="WED"/>
-                <TextView style="@style/WeekLabel" android:text="THU"/>
-                <TextView style="@style/WeekLabel" android:text="FRI"/>
-                <TextView style="@style/WeekLabel" android:text="SAT"/>
-            </LinearLayout>
-
-            <!-- Grid (6x7) -->
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rvDays"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:nestedScrollingEnabled="false"/>
-        </LinearLayout>
+        <ImageButton
+            android:id="@+id/btn_next"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_chevron_right" />
     </LinearLayout>
+
+    <!-- Day of Week Header -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp">
+
+        <TextView
+            style="@style/DayOfWeekText"
+            android:text="SUN" />
+        <TextView
+            style="@style/DayOfWeekText"
+            android:text="MON" />
+        <TextView
+            style="@style/DayOfWeekText"
+            android:text="TUE" />
+        <TextView
+            style="@style/DayOfWeekText"
+            android:text="WED" />
+        <TextView
+            style="@style/DayOfWeekText"
+            android:text="THU" />
+        <TextView
+            style="@style/DayOfWeekText"
+            android:text="FRI" />
+        <TextView
+            style="@style/DayOfWeekText"
+            android:text="SAT" />
+    </LinearLayout>
+
+    <!-- Days Grid -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_days"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="16dp"
+        android:background="@android:color/darker_gray" />
+
+    <!-- Events List -->
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_events"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:listitem="@layout/item_calendar_event" />
+
+        <TextView
+            android:id="@+id/tv_no_events"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="예정된 이벤트가 없습니다."
+            android:textSize="16sp"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </FrameLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/item_calendar_event.xml
+++ b/app/src/main/res/layout/item_calendar_event.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="8dp">
+
+    <View
+        android:id="@+id/view_event_color"
+        android:layout_width="4dp"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="12dp"
+        android:background="@android:color/holo_red_light" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tv_event_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            tools:text="[행사] 2024년 여름방학 코딩 캠프" />
+
+        <TextView
+            android:id="@+id/tv_event_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/darker_gray"
+            android:textSize="14sp"
+            tools:text="17:00" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_day.xml
+++ b/app/src/main/res/layout/item_day.xml
@@ -1,16 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="48dp"
-    android:layout_marginVertical="3dp"
-    android:layout_weight="1">
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:minHeight="48dp"
+    android:orientation="vertical"
+    android:padding="8dp">
 
     <TextView
-        android:id="@+id/tvDay"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:layout_gravity="center"
+        android:id="@+id/tv_day"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:gravity="center"
-        android:textSize="14sp"
-        android:background="@android:color/transparent"/>
-</FrameLayout>
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        tools:text="20" />
+
+    <View
+        android:id="@+id/event_indicator"
+        android:layout_width="4dp"
+        android:layout_height="4dp"
+        android:layout_marginTop="2dp"
+        android:background="@drawable/bg_event_indicator"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+</LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,4 +13,12 @@
         <item name="android:textColor">#9AA0A6</item>
         <item name="android:textSize">10sp</item>
     </style>
+
+    <style name="DayOfWeekText">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:gravity">center</item>
+        <item name="android:textAppearance">@style/TextAppearance.AppCompat.Caption</item>
+    </style>
 </resources>


### PR DESCRIPTION
    feat: 내부 캘린더 기능 구현 및 전체 연동

    - 외부 캘린더 연동 기능을 내부 Room DB 기반의 캘린더로 대체
    - 게시물 목록, 상세화면, 사이트별 목록의 토글 버튼 상태가 DB를 통해 동기화되도록 데이터 흐름 수정
    - 사용자가 토글 버튼으로 '저장'한 게시물만 캘린더 탭에 표시
    - 캘린더 날짜 셀 UI 개선
    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 에뮬레이터 테스트용 기본 서버 주소 활성화
  * 캘린더에 저장된 게시물을 이벤트로 표시하고 이벤트 목록에서 확인 가능
  * 이벤트 목록 아이템 및 좌/우 네비게이션 아이콘 추가

* **버그 수정**
  * 서버 날짜 포맷 복수 패턴 지원 및 로컬 날짜 변환 정확도 향상

* **스타일**
  * 캘린더 헤더·일자 레이아웃 단순화, 이벤트 인디케이터 및 선택 일자 스타일 개선

* **리팩토링**
  * 게시물 저장/표시 흐름이 로컬 DB 관찰·동기화 기반으로 전환되어 UI가 실시간 갱신됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->